### PR TITLE
Broken links, and content updation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "https://forgefed.io"
+base_url = "https://forgeflux.org"
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true

--- a/content/community/index.md
+++ b/content/community/index.md
@@ -9,11 +9,11 @@ images: []
 
 ## Matrix Community
 
-Come say hi at our [Matrix community](https://matrix.to/#/#forgefedv2:matrix.batsense.net)
+Come say hi at our [Matrix community](https://matrix.to/#/#forgefedv2:matrix.batsense.net)!
 
 ## Discord(Bridged with Matrix)
 
-We also have a [Discord server!](https://discord.gg/sE6B28fvbP)
+We also have a [Discord server](https://discord.gg/sE6B28fvbP)!
 
 ## Forum
 
@@ -23,4 +23,4 @@ take part in discussions related to the project!
 
 ## Bug reports
 
-We GitHub for managing tickets
+We use GitHub for managing tickets, on our various projects, check that out [here](https://github.com/forgeflux-org/).

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -17,6 +17,6 @@
   <div class="nav__link-group">
     {{ macros::nav_link(link="/community", name="Community") }} 
     {{ macros::nav_link(link="https://forum.forgefriends.org/c/development/forgefed-io/28", name="Forum") }}
-    {{ macros::nav_link(link="https://github.com/forgefedv2", name="Source Code") }}
+    {{ macros::nav_link(link="https://github.com/forgeflux-org", name="Source Code") }}
   </div>
 </nav>


### PR DESCRIPTION
## Changelog
- Fixed a few broken links that pointed to the previous name for the organization.
- Completed the line about Bug Reports in the `content/community/index` section.

##  Note
Checked whether the matrix room link worked, and it seems as such that it does, no changes are required there, but, something to note if the Matrix Space name does change.